### PR TITLE
Feature/42/이미지피커에서 셀 3개 선택 시 나머지 셀 투명도 조정

### DIFF
--- a/TravelGenie/TravelGenie/Presentation/Chat/View/CustomImagePicker/CustomImagePickerViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/CustomImagePicker/CustomImagePickerViewController.swift
@@ -230,8 +230,7 @@ extension CustomImagePickerViewController: UICollectionViewDataSource {
     {
         guard let cell = collectionView.cellForItem(at: indexPath) as? CustomImagePickerCell else { return }
         
-        let imageData = cell.image()?.pngData()
-        viewModel.removeImage(data: imageData)
+        viewModel.removeImage(at: indexPath)
         cell.configureDeselectedState(viewModel.selectedPhotos.count)
         
         if !viewModel.selectedPhotos.isEmpty {

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/CustomImagePicker/CustomImagePickerViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/CustomImagePicker/CustomImagePickerViewController.swift
@@ -214,6 +214,14 @@ extension CustomImagePickerViewController: UICollectionViewDataSource {
         let imageData = cell.image()?.pngData()
         viewModel.addImage(indexPath: indexPath, imageData: imageData)
         cell.configureSelectedState(viewModel.selectedPhotos.count)
+        
+        if viewModel.selectedPhotos.count == 3 {
+            guard let cells = collectionView.visibleCells as? [CustomImagePickerCell] else { return }
+            
+            cells.forEach {
+                if !$0.isSelected { $0.layer.opacity = 0.2 }
+            }
+        }
     }
     
     func collectionView(
@@ -233,6 +241,14 @@ extension CustomImagePickerViewController: UICollectionViewDataSource {
                 else { return }
                 
                 cell.configureSelectedState(index)
+            }
+        }
+        
+        if viewModel.selectedPhotos.count < 3 {
+            guard let cells = collectionView.visibleCells as? [CustomImagePickerCell] else { return }
+            
+            cells.forEach {
+                if !$0.isSelected { $0.layer.opacity = 1 }
             }
         }
     }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomImagePickerViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomImagePickerViewModel.swift
@@ -26,8 +26,8 @@ final class CustomImagePickerViewModel {
         selectedPhotos.append((indexPath: indexPath, imageData: imageData))
     }
     
-    func removeImage(data: Data?) {
-        selectedPhotos = selectedPhotos.filter { $0.imageData != data }
+    func removeImage(at indexPath: IndexPath) {
+        selectedPhotos = selectedPhotos.filter { $0.indexPath != indexPath }
     }
     
     func isSelected(selectedIndexPath: IndexPath) -> Int? {


### PR DESCRIPTION
Resolves #80 

- 이미지피커에서 셀 3개 선택 시 나머지 셀의 투명도를 0.2로 조정
- 이미지피커 deselect 시 제대로 데이터가 삭제되지 않는 오류 해결