### PR TITLE
Feature/44/이미지 압축 기능

### DIFF
--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		57462B792A96302C00949D5C /* RecommendationEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57462B772A96302C00949D5C /* RecommendationEntity+CoreDataProperties.swift */; };
 		57462B7C2A9630D200949D5C /* TagEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57462B7A2A9630D200949D5C /* TagEntity+CoreDataClass.swift */; };
 		57462B7D2A9630D200949D5C /* TagEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57462B7B2A9630D200949D5C /* TagEntity+CoreDataProperties.swift */; };
+		57567F812AAF13EF00B1F7CB /* ImageCompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57567F802AAF13EF00B1F7CB /* ImageCompressor.swift */; };
 		5763DEEB2A9885E40028B19F /* FeedbackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DEEA2A9885E40028B19F /* FeedbackButton.swift */; };
 		5763DEEF2A9896EE0028B19F /* FeedbackTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DEEE2A9896EE0028B19F /* FeedbackTextView.swift */; };
 		5763DEF12A98FA950028B19F /* PopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DEF02A98FA950028B19F /* PopUpViewController.swift */; };
@@ -193,6 +194,7 @@
 		57462B772A96302C00949D5C /* RecommendationEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecommendationEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		57462B7A2A9630D200949D5C /* TagEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		57462B7B2A9630D200949D5C /* TagEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		57567F802AAF13EF00B1F7CB /* ImageCompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCompressor.swift; sourceTree = "<group>"; };
 		5763DEEA2A9885E40028B19F /* FeedbackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackButton.swift; sourceTree = "<group>"; };
 		5763DEEE2A9896EE0028B19F /* FeedbackTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackTextView.swift; sourceTree = "<group>"; };
 		5763DEF02A98FA950028B19F /* PopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpViewController.swift; sourceTree = "<group>"; };
@@ -576,6 +578,7 @@
 			isa = PBXGroup;
 			children = (
 				57DA988A2A9F8C830074409B /* ImageManager.swift */,
+				57567F802AAF13EF00B1F7CB /* ImageCompressor.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -1071,6 +1074,7 @@
 				57A54C8E2AA8D8B50087B640 /* CustomImagePickerHeaderView.swift in Sources */,
 				573BCD5A2A925C2F00116D2D /* ChatListViewModel.swift in Sources */,
 				57A54C8A2AA8CB280087B640 /* CustomImagePickerCell.swift in Sources */,
+				57567F812AAF13EF00B1F7CB /* ImageCompressor.swift in Sources */,
 				D20FA2752A6B8DA90081B039 /* SceneDelegate.swift in Sources */,
 				D2E81B8E2A913AF8006A5236 /* TagCollectionHeaderView.swift in Sources */,
 				D272925F2AA5E3D8001878D0 /* ChatHistoryCoordinator.swift in Sources */,

--- a/TravelGenie/TravelGenie.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TravelGenie/TravelGenie.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "cf62cdaea48b77f1a631e5cb3aeda6047c2cba1d",
-        "version" : "1.23.0"
+        "revision" : "ce20dc083ee485524b802669890291c0d8090170",
+        "version" : "1.22.1"
       }
     }
   ],

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/CustomImagePicker/CustomImagePickerViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/CustomImagePicker/CustomImagePickerViewController.swift
@@ -209,9 +209,10 @@ extension CustomImagePickerViewController: UICollectionViewDataSource {
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath)
     {
-        guard let cell = collectionView.cellForItem(at: indexPath) as? CustomImagePickerCell else { return }
+        guard let cell = collectionView.cellForItem(at: indexPath) as? CustomImagePickerCell,
+              let imageData = cell.image()?.pngData()
+        else { return }
         
-        let imageData = cell.image()?.pngData()
         viewModel.addImage(indexPath: indexPath, imageData: imageData)
         cell.configureSelectedState(viewModel.selectedPhotos.count)
         

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomImagePickerViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomImagePickerViewModel.swift
@@ -16,13 +16,13 @@ final class CustomImagePickerViewModel {
     weak var delegate: ImagePickerDelegate?
     var selectedPhotoCountChanged: ((Int) -> Void)?
     
-    private(set) var selectedPhotos: [(indexPath: IndexPath, imageData: Data?)] = [] {
+    private(set) var selectedPhotos: [(indexPath: IndexPath, imageData: Data)] = [] {
         didSet {
             selectedPhotoCountChanged?(selectedPhotos.count)
         }
     }
     
-    func addImage(indexPath: IndexPath, imageData: Data?) {
+    func addImage(indexPath: IndexPath, imageData: Data) {
         selectedPhotos.append((indexPath: indexPath, imageData: imageData))
     }
     

--- a/TravelGenie/TravelGenie/Utility/ImageCompressor.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageCompressor.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 struct ImageCompressor {
+    
     static func compress(
         image: UIImage,
         maxByte: Int,

--- a/TravelGenie/TravelGenie/Utility/ImageCompressor.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageCompressor.swift
@@ -10,12 +10,13 @@ import UIKit
 struct ImageCompressor {
     
     static func compress(
-        image: UIImage,
-        maxByte: Int,
+        imageData: Data,
+        maxByte: Int = 1_024_000,
         completion: @escaping (Data?) -> Void)
     {
         DispatchQueue.global().async {
-            guard let currentImageSize = image.jpegData(compressionQuality: 1.0)?.count else {
+            guard let image = UIImage(data: imageData),
+                  let currentImageSize = image.jpegData(compressionQuality: 1.0)?.count else {
                 return completion(nil)
             }
             

--- a/TravelGenie/TravelGenie/Utility/ImageCompressor.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageCompressor.swift
@@ -31,10 +31,7 @@ struct ImageCompressor {
                     width: image.size.width * iterationCompression,
                     height: image.size.height * iterationCompression)
                 
-                UIGraphicsBeginImageContextWithOptions(canvasSize, false, image.scale)
-                defer { UIGraphicsEndImageContext() }
-                image.draw(in: CGRect(origin: .zero, size: canvasSize))
-                iterationImage = UIGraphicsGetImageFromCurrentImageContext()
+                iterationImage = image.resize(width: canvasSize.width, height: canvasSize.height)
                 
                 guard let newImageSize = iterationImage?.jpegData(compressionQuality: 1.0)?.count else {
                     return completion(nil)

--- a/TravelGenie/TravelGenie/Utility/ImageCompressor.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageCompressor.swift
@@ -1,0 +1,59 @@
+//
+//  ImageCompressor.swift
+//  TravelGenie
+//
+//  Created by summercat on 2023/09/11.
+//
+
+import UIKit
+
+struct ImageCompressor {
+    static func compress(
+        image: UIImage,
+        maxByte: Int,
+        completion: @escaping (Data?) -> Void)
+    {
+        DispatchQueue.global().async {
+            guard let currentImageSize = image.jpegData(compressionQuality: 1.0)?.count else {
+                return completion(nil)
+            }
+            
+            var iterationImage: UIImage? = image
+            var iterationImageSize = currentImageSize
+            var iterationCompression: CGFloat = 1.0
+            
+            while iterationImageSize > maxByte,
+                  iterationCompression > 0.01 {
+                let percentageDecrease = getPercentageToDecreaseTo(forDataCount: iterationImageSize)
+                let canvasSize = CGSize(
+                    width: image.size.width * iterationCompression,
+                    height: image.size.height * iterationCompression)
+                
+                UIGraphicsBeginImageContextWithOptions(canvasSize, false, image.scale)
+                defer { UIGraphicsEndImageContext() }
+                image.draw(in: CGRect(origin: .zero, size: canvasSize))
+                iterationImage = UIGraphicsGetImageFromCurrentImageContext()
+                
+                guard let newImageSize = iterationImage?.jpegData(compressionQuality: 1.0)?.count else {
+                    return completion(nil)
+                }
+                
+                iterationImageSize = newImageSize
+                iterationCompression -= percentageDecrease
+            }
+            
+            completion(iterationImage?.jpegData(compressionQuality: 1.0))
+        }
+    }
+    
+    private static func getPercentageToDecreaseTo(forDataCount dataCount: Int) -> CGFloat {
+        switch dataCount {
+        case 0..<5_000_000:
+            return 0.03
+        case 5_000_000..<10_000_000:
+            return 0.1
+        default:
+            return 0.2
+        }
+    }
+}

--- a/TravelGenie/TravelGenie/Utility/ImageManager.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageManager.swift
@@ -8,12 +8,13 @@
 import UIKit
 
 final class ImageManager {
+    
     static let cache: URLCache = URLCache.shared
     
     static func retrieveImage(
         with url: String,
-        completion: @escaping (Data) -> Void
-    ) {
+        completion: @escaping (Data) -> Void)
+    {
         guard let url = URL(string: url) else { return }
         
         let request: URLRequest = URLRequest(url: url)
@@ -32,8 +33,8 @@ final class ImageManager {
     
     private static func downloadImage(
         with request: URLRequest,
-        completion: @escaping (Data) -> Void
-    ) {
+        completion: @escaping (Data) -> Void)
+    {
         let task = URLSession.shared.dataTask(with: request) { data, response, _ in
             guard let data = data,
                   let image = UIImage(data: data),

--- a/TravelGenie/TravelGenie/Utility/ImageManager.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageManager.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class ImageManager {
-    static let cache: URLCache = URLCache()
+    static let cache: URLCache = URLCache.shared
     
     static func retrieveImage(
         with url: String,

--- a/TravelGenie/TravelGenie/Utility/ImageManager.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageManager.swift
@@ -37,11 +37,10 @@ final class ImageManager {
     {
         let task = URLSession.shared.dataTask(with: request) { data, response, _ in
             guard let data = data,
-                  let image = UIImage(data: data),
                   let response = response as? HTTPURLResponse,
                   (200..<300) ~= response.statusCode else { return }
             
-            ImageCompressor.compress(image: image, maxByte: 1024_000) { compressedImageData in
+            ImageCompressor.compress(imageData: data) { compressedImageData in
                 guard let compressedImageData else { return }
                 
                 let cachedResponse: CachedURLResponse = CachedURLResponse(response: response, data: compressedImageData)


### PR DESCRIPTION
Resolves #79 

[링크](https://stackoverflow.com/a/63646222)를 참고하여 `ImageManager`를 통해 가져온 이미지, 사용자가 선택한 사진을 압축하는 기능을 추가했습니다.

```swift
struct ImageCompressor {
    
    static func compress(
        imageData: Data,
        maxByte: Int = 1_024_000,
        completion: @escaping (Data?) -> Void)
    {
        DispatchQueue.global().async {
            guard let image = UIImage(data: imageData),
                  let currentImageSize = image.jpegData(compressionQuality: 1.0)?.count else {
                return completion(nil)
            }
            
            var iterationImage: UIImage? = image
            var iterationImageSize = currentImageSize
            var iterationCompression: CGFloat = 1.0
            
            while iterationImageSize > maxByte,
                  iterationCompression > 0.01 {
                let percentageDecrease = getPercentageToDecreaseTo(forDataCount: iterationImageSize)
                let canvasSize = CGSize(
                    width: image.size.width * iterationCompression,
                    height: image.size.height * iterationCompression)
                
                iterationImage = image.resize(width: canvasSize.width, height: canvasSize.height)
                
                guard let newImageSize = iterationImage?.jpegData(compressionQuality: 1.0)?.count else {
                    return completion(nil)
                }
                
                iterationImageSize = newImageSize
                iterationCompression -= percentageDecrease
            }
            
            completion(iterationImage?.jpegData(compressionQuality: 1.0))
        }
    }
    
    private static func getPercentageToDecreaseTo(forDataCount dataCount: Int) -> CGFloat {
        switch dataCount {
        case 0..<5_000_000:
            return 0.03
        case 5_000_000..<10_000_000:
            return 0.1
        default:
            return 0.2
        }
    }
}
```

용량이 큰 이미지일 수록 압축 비율을 높게 해서 설정한 `maxByte` 크기 미만이 될 때까지 이미지를 반복해서 압축하는 방식입니다.
압축 과정은 아래의 과정을 순서대로 반복합니다.
  1. 압축할 비율(줄일 비율. 예: 0.1만큼 줄인다)을 구한다.
  2. 해당 비율에 맞추어 `canvasSize`를 생성한다.
  3. 해당 `canvasSize`에 맞추어 이미지를 리사이징 한다.
  4. 리시아징한 이미지의 크기를 구하고, 위의 과정을 반복한다.

---

### 참고 링크와 프로젝트 내부 구현 간의 차이점

- 이미지 데이터 매개변수/반환 타입을 `UIImage`에서 `Data`로 변경
  - 뷰모델과 같이 로직을 처리하는 객체에서 호출하는 경우가 많기 때문에, 해당 객체에서 `import UIKit`하지 않아도 되도록 이미지 데이터와 관련한 매개변수/반환 타입을 `Data` 타입으로 변경하였습니다.
- `maxByte`에 1MB를 기본값으로 설정
  - 1MB로 설정한 이유는 카카오톡에서 사진을 'Standard Quality'로 압축해서 보낼 때 파일 크기가 100Kb ~ 700Kb 사이였기 때문에 1MB 정도면 충분하다고 생각했습니다.
- `UIGraphicsBeginImageContext`를 사용하지 않도록 변경
  - 공식문서를 확인해 보니 iOS17.0 이후 deprecated 될 예정이어서, `UIGraphicsImageRenderer`를 사용하는 메서드를 이용하도록 내부 구현을 변경해 주었습니다 (`UIGraphicsImageRenderer`는 iOS10.0 이상에서 사용 가능)