### PR TITLE
Feature/45/홈 화면 메뉴 버튼에 URL 연결 기능 추가

### DIFF
--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		57DA988B2A9F8C830074409B /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DA988A2A9F8C830074409B /* ImageManager.swift */; };
 		57DA988F2AA0663C0074409B /* CoreDataChatStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DA988E2AA0663C0074409B /* CoreDataChatStorage.swift */; };
 		57DA98912AA0BECC0074409B /* AttributedTextCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DA98902AA0BECC0074409B /* AttributedTextCellSizeCalculator.swift */; };
+		57EA83162AB06DDF00AB872B /* SelfSizingTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EA83152AB06DDF00AB872B /* SelfSizingTableView.swift */; };
 		D20FA2732A6B8DA90081B039 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20FA2722A6B8DA90081B039 /* AppDelegate.swift */; };
 		D20FA2752A6B8DA90081B039 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20FA2742A6B8DA90081B039 /* SceneDelegate.swift */; };
 		D20FA27C2A6B8DAC0081B039 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D20FA27B2A6B8DAC0081B039 /* Assets.xcassets */; };
@@ -236,6 +237,7 @@
 		57DA988A2A9F8C830074409B /* ImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
 		57DA988E2AA0663C0074409B /* CoreDataChatStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataChatStorage.swift; sourceTree = "<group>"; };
 		57DA98902AA0BECC0074409B /* AttributedTextCellSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedTextCellSizeCalculator.swift; sourceTree = "<group>"; };
+		57EA83152AB06DDF00AB872B /* SelfSizingTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSizingTableView.swift; sourceTree = "<group>"; };
 		D20FA26F2A6B8DA90081B039 /* TravelGenie.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TravelGenie.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D20FA2722A6B8DA90081B039 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D20FA2742A6B8DA90081B039 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -350,6 +352,7 @@
 				573BCD012A8BAF7600116D2D /* HomeViewController.swift */,
 				573BCD0C2A8BC10E00116D2D /* HomeMenuButton.swift */,
 				573BCD1A2A8E543800116D2D /* BottomMenuCell.swift */,
+				57EA83152AB06DDF00AB872B /* SelfSizingTableView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -985,6 +988,7 @@
 				D2E81B8A2A9116F6006A5236 /* ContentItem.swift in Sources */,
 				5763DF072A9CA8020028B19F /* ChatInterfaceViewModel.swift in Sources */,
 				573BCD042A8BAF7600116D2D /* HomeViewController.swift in Sources */,
+				57EA83162AB06DDF00AB872B /* SelfSizingTableView.swift in Sources */,
 				D268468A2AA10A5600831097 /* TranslateDTO.swift in Sources */,
 				D2833A302A8E1578000FEE30 /* MessageStorage.swift in Sources */,
 				D2E3AA332A8B83520049DDEF /* ChatInterfaceViewController.swift in Sources */,

--- a/TravelGenie/TravelGenie/Presentation/Home/BottomMenuItem.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/BottomMenuItem.swift
@@ -6,6 +6,34 @@
 //
 
 struct BottomMenuItem {
-    var title: String
-    var description: String
+    
+    enum ItemType {
+        case termsOfService
+        case privacyPolicy
+        case inquiries
+    }
+    
+    let type: ItemType
+    
+    var title: String {
+        switch type {
+        case .termsOfService:
+            return "서비스 이용약관"
+        case .privacyPolicy:
+            return "개인정보처리방침"
+        case .inquiries:
+            return "문의"
+        }
+    }
+    
+    var url: String {
+        switch type {
+        case .termsOfService:
+            return "https://github.com/Team-TravelGenie/TripChat"
+        case .privacyPolicy:
+            return "https://github.com/Team-TravelGenie/TripChat"
+        case .inquiries:
+            return "https://github.com/Team-TravelGenie/TripChat"
+        }
+    }
 }

--- a/TravelGenie/TravelGenie/Presentation/Home/View/BottomMenuCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/View/BottomMenuCell.swift
@@ -69,7 +69,7 @@ final class BottomMenuCell: UITableViewCell {
             iconImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             iconImageView.widthAnchor.constraint(equalToConstant: 12),
-            iconImageView.heightAnchor.constraint(equalToConstant: 24),
+            iconImageView.heightAnchor.constraint(equalToConstant: 20),
         ])
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Home/View/BottomMenuCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/View/BottomMenuCell.swift
@@ -12,7 +12,7 @@ final class BottomMenuCell: UITableViewCell {
     static var identifier: String { return String(describing: self) }
     
     private let titleLabel = UILabel()
-    private let iconImageView = UIImageView()
+    private let disclosureIconImageView = UIImageView()
     
     // MARK: Lifecycle
 
@@ -49,12 +49,12 @@ final class BottomMenuCell: UITableViewCell {
     
     private func configureDisclosureIcon() {
         let icon: UIImage? = UIImage(systemName: "chevron.right")
-        iconImageView.image = icon
-        iconImageView.tintColor = .blueGrayFont
+        disclosureIconImageView.image = icon
+        disclosureIconImageView.tintColor = .blueGrayFont
     }
     
     private func configureHierarchy() {
-        [titleLabel, iconImageView].forEach { contentView.addSubview($0) }
+        [titleLabel, disclosureIconImageView].forEach { contentView.addSubview($0) }
     }
     
     private func configureLayout() {
@@ -64,12 +64,12 @@ final class BottomMenuCell: UITableViewCell {
             titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
         ])
         
-        iconImageView.translatesAutoresizingMaskIntoConstraints = false
+        disclosureIconImageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            iconImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            iconImageView.widthAnchor.constraint(equalToConstant: 12),
-            iconImageView.heightAnchor.constraint(equalToConstant: 20),
+            disclosureIconImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            disclosureIconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            disclosureIconImageView.widthAnchor.constraint(equalToConstant: 12),
+            disclosureIconImageView.heightAnchor.constraint(equalToConstant: 20),
         ])
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Home/View/BottomMenuCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/View/BottomMenuCell.swift
@@ -16,7 +16,10 @@ final class BottomMenuCell: UITableViewCell {
     
     // MARK: Lifecycle
 
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override init(
+        style: UITableViewCell.CellStyle,
+        reuseIdentifier: String?)
+    {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         selectionStyle = .none
         backgroundColor = .clear

--- a/TravelGenie/TravelGenie/Presentation/Home/View/HomeViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/View/HomeViewController.swift
@@ -43,8 +43,10 @@ final class HomeViewController: UIViewController {
     // MARK: Private
     
     private func bind() {
-        viewModel.showBottomMenu = { [weak self] item in
-            self?.showTermsDetail(item: item)
+        viewModel.bottomMenuCellTapped = { [weak self] url in
+            guard let url = url else { return }
+            
+            self?.showWebLink(url: url)
         }
     }
     
@@ -201,8 +203,8 @@ final class HomeViewController: UIViewController {
         coverView.backgroundColor = .white
     }
     
-    private func showTermsDetail(item: BottomMenuItem) {
-        // TODO: - 서비스 이용약관, 개인정보 처리방침 modal
+    private func showWebLink(url: URL) {
+        UIApplication.shared.open(url)
     }
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Home/View/HomeViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/View/HomeViewController.swift
@@ -17,7 +17,7 @@ final class HomeViewController: UIViewController {
     private let bodyTextView = UITextView()
     private let chatButton = HomeMenuButton()
     private let chatListButton = HomeMenuButton()
-    private let bottomMenuTableView = UITableView(frame: .zero, style: .plain)
+    private let bottomMenuTableView = SelfSizingTableView(frame: .zero, style: .plain)
     private let coverView = UIView()
     
     // MARK: Lifecycle
@@ -121,7 +121,6 @@ final class HomeViewController: UIViewController {
             bottomMenuTableView.topAnchor.constraint(equalTo: chatButton.bottomAnchor, constant: 52),
             bottomMenuTableView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             bottomMenuTableView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
-            bottomMenuTableView.heightAnchor.constraint(equalToConstant: 112),
         ])
         
         coverView.translatesAutoresizingMaskIntoConstraints = false

--- a/TravelGenie/TravelGenie/Presentation/Home/View/HomeViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/View/HomeViewController.swift
@@ -211,22 +211,40 @@ final class HomeViewController: UIViewController {
 // MARK: UITableViewDataSource & UITableViewDelegate
 
 extension HomeViewController: UITableViewDataSource, UITableViewDelegate {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    func tableView(
+        _ tableView: UITableView,
+        numberOfRowsInSection section: Int)
+        -> Int
+    {
         return viewModel.bottomMenus.count
     }
     
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: BottomMenuCell.identifier, for: indexPath) as? BottomMenuCell else { return UITableViewCell() }
+    func tableView(
+        _ tableView: UITableView,
+        cellForRowAt indexPath: IndexPath)
+        -> UITableViewCell
+    {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: BottomMenuCell.identifier,
+            for: indexPath) as? BottomMenuCell else { return UITableViewCell() }
+        
         cell.setTitle(with: viewModel.bottomMenus[indexPath.row].title)
 
         return cell
     }
     
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    func tableView(
+        _ tableView: UITableView,
+        heightForRowAt indexPath: IndexPath)
+        -> CGFloat
+    {
         return 56
     }
     
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    func tableView(
+        _ tableView: UITableView,
+        didSelectRowAt indexPath: IndexPath)
+    {
         viewModel.didTapBottomMenuCell(at: indexPath.row)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Home/View/SelfSizingTableView.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/View/SelfSizingTableView.swift
@@ -1,0 +1,22 @@
+//
+//  SelfSizingTableView.swift
+//  TravelGenie
+//
+//  Created by summercat on 2023/09/12.
+//
+
+import UIKit
+
+final class SelfSizingTableView: UITableView {
+
+    override var intrinsicContentSize: CGSize {
+        let height = contentSize.height + contentInset.top + contentInset.bottom
+        
+        return CGSize(width: self.contentSize.width, height: height)
+    }
+    
+    override func layoutSubviews() {
+        invalidateIntrinsicContentSize()
+        super.layoutSubviews()
+    }
+}

--- a/TravelGenie/TravelGenie/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -12,9 +12,10 @@ final class HomeViewModel {
     weak var coordinator: HomeCoordinator?
     var showBottomMenu: ((BottomMenuItem) -> Void)?
     
-    var bottomMenus: [BottomMenuItem] = [
+    let bottomMenus: [BottomMenuItem] = [
         BottomMenuItem(type: .termsOfService),
         BottomMenuItem(type: .privacyPolicy),
+        BottomMenuItem(type: .inquiries),
     ]
     
     func didTapNewChatButton() {

--- a/TravelGenie/TravelGenie/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 final class HomeViewModel {
     
     weak var coordinator: HomeCoordinator?
-    var showBottomMenu: ((BottomMenuItem) -> Void)?
+    var bottomMenuCellTapped: ((URL?) -> Void)?
     
     let bottomMenus: [BottomMenuItem] = [
         BottomMenuItem(type: .termsOfService),
@@ -26,8 +26,10 @@ final class HomeViewModel {
         coordinator?.chatListFlow()
     }
     
-    // TODO: 코디네이터 패턴 적용으로 변경
     func didTapBottomMenuCell(at row: Int) {
-        showBottomMenu?(bottomMenus[row])
+        let selectedMenu = bottomMenus[row]
+        let url = URL(string: selectedMenu.url)
+
+        bottomMenuCellTapped?(url)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -13,8 +13,8 @@ final class HomeViewModel {
     var showBottomMenu: ((BottomMenuItem) -> Void)?
     
     var bottomMenus: [BottomMenuItem] = [
-        BottomMenuItem(title: "서비스 이용약관", description: ""),
-        BottomMenuItem(title: "개인정보처리방침", description: ""),
+        BottomMenuItem(type: .termsOfService),
+        BottomMenuItem(type: .privacyPolicy),
     ]
     
     func didTapNewChatButton() {


### PR DESCRIPTION
Resolves #28 

<img width="551" alt="image" src="https://github.com/Team-TravelGenie/TripChat/assets/98260324/fe325197-93b5-4050-9d43-77189524f06a">

홈 화면 하단 영역 버튼 탭 시 URL 링크로 연결하는 기능을 추가하였습니다.
  - 현재는 TripChat 레포지토리 URL로 연결되게 설정되어 있습니다.
  - `문의`의 경우, 이메일로 문의를 받기로 했는데 이 경우 어떻게 처리할지 아직 기획/디자인이 없어 문의해 두었습니다.

기존 `BottomMenuItem` 리팩토링
  - `type` 프로퍼티 추가
  - `url` 프로퍼티 추가
  - `description` 프로퍼티 제거: 더 이상 앱 내에서 이용약관 세부사항 등을 보여주지 않기 때문에 필요 없다고 판단