### PR TITLE
Feature/46/태그셀 리팩토링

### DIFF
--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		D2833A302A8E1578000FEE30 /* MessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */; };
 		D29DBD352A9F7EA100C856C0 /* VisionResultProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29DBD342A9F7EA100C856C0 /* VisionResultProcessor.swift */; };
 		D2C2476B2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */; };
+		D2D7DD182AB4345A0045D1EC /* TagMessageInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D7DD172AB4345A0045D1EC /* TagMessageInteractionState.swift */; };
 		D2E3AA262A8B62320049DDEF /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E3AA252A8B62320049DDEF /* ChatViewController.swift */; };
 		D2E3AA282A8B62400049DDEF /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E3AA272A8B62400049DDEF /* ChatViewModel.swift */; };
 		D2E3AA2D2A8B64740049DDEF /* MessageKit in Frameworks */ = {isa = PBXBuildFile; productRef = D2E3AA2C2A8B64740049DDEF /* MessageKit */; };
@@ -269,6 +270,7 @@
 		D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStorage.swift; sourceTree = "<group>"; };
 		D29DBD342A9F7EA100C856C0 /* VisionResultProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionResultProcessor.swift; sourceTree = "<group>"; };
 		D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonMessageCellSizeCalculator.swift; sourceTree = "<group>"; };
+		D2D7DD172AB4345A0045D1EC /* TagMessageInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagMessageInteractionState.swift; sourceTree = "<group>"; };
 		D2E3AA252A8B62320049DDEF /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
 		D2E3AA272A8B62400049DDEF /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		D2E3AA322A8B83520049DDEF /* ChatInterfaceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInterfaceViewController.swift; sourceTree = "<group>"; };
@@ -838,6 +840,7 @@
 			isa = PBXGroup;
 			children = (
 				D24DF9C32A9695BB0066C5B3 /* TagStorage.swift */,
+				D2D7DD172AB4345A0045D1EC /* TagMessageInteractionState.swift */,
 				D2F8C57D2A8F4AEF00AA3BFC /* CustomTagContentCell.swift */,
 				D2F8C5812A8F538500AA3BFC /* TagView */,
 			);
@@ -956,6 +959,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				57DA98742A9E3B580074409B /* ImageSearchDTO.swift in Sources */,
+				D2D7DD182AB4345A0045D1EC /* TagMessageInteractionState.swift in Sources */,
 				57C2BEF72AA47D1D0074DA8C /* CustomInputBarAccessoryView.swift in Sources */,
 				D20FA2A82A6BD4830081B039 /* GoogleVisionRequestModel.swift in Sources */,
 				573BCD262A8F46B900116D2D /* ChatCoordinator.swift in Sources */,

--- a/TravelGenie/TravelGenie.xcodeproj/xcuserdata/hyeonung-seo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/TravelGenie/TravelGenie.xcodeproj/xcuserdata/hyeonung-seo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -91,7 +91,7 @@
 		<key>TravelGenie.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/TravelGenie/TravelGenie.xcodeproj/xcuserdata/hyeonung-seo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/TravelGenie/TravelGenie.xcodeproj/xcuserdata/hyeonung-seo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -91,7 +91,7 @@
 		<key>TravelGenie.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/TravelGenie/TravelGenie/Domain/Entity/ContentItem.swift
+++ b/TravelGenie/TravelGenie/Domain/Entity/ContentItem.swift
@@ -59,6 +59,7 @@ struct Tag: Codable {
 enum Category: String, Codable {
     case location
     case theme
+    case keyword
 }
 
 // MARK: MessageKind - .custom(RecommendationItem) 메시지 컨텐츠

--- a/TravelGenie/TravelGenie/Domain/Model/MessageStorage.swift
+++ b/TravelGenie/TravelGenie/Domain/Model/MessageStorage.swift
@@ -15,13 +15,13 @@ final class MessageStorage {
         return messageList.count
     }
     var didChangeMessageList: (() -> Void)?
-
+    
     private var messageList: [Message] = [Message]() {
         didSet {
             didChangeMessageList?()
         }
     }
-        
+    
     // MARK: Internal
     
     func insertMessage(_ message: Message) {
@@ -45,11 +45,22 @@ final class MessageStorage {
         })
     }
     
-    func updateTagMessage(_ message: Message) {
+    func updateTagMessage(_ tags: [Tag]) {
         guard let index = findTagMessageIndex() else { return }
+        var tagMessage = messageList[index]
         
-        messageList[index] = message
+        if case let .custom(tagItem) = tagMessage.kind, let currentTagItem = tagItem as? TagItem {
+            var currentTags = currentTagItem.tags
+            
+            for newTag in tags {
+                if let matchingTagIndex = currentTags.firstIndex(where: { $0.value == newTag.value }) {
+                    currentTags[matchingTagIndex].isSelected = newTag.isSelected
+                }
+            }
+            
+            let updatedTagItem = TagItem(tags: currentTags)
+            tagMessage.kind = .custom(updatedTagItem)
+            messageList[index] = tagMessage
+        }
     }
-    
-    
 }

--- a/TravelGenie/TravelGenie/Domain/Model/MessageStorage.swift
+++ b/TravelGenie/TravelGenie/Domain/Model/MessageStorage.swift
@@ -44,4 +44,12 @@ final class MessageStorage {
             return false
         })
     }
+    
+    func updateTagMessage(_ message: Message) {
+        guard let index = findTagMessageIndex() else { return }
+        
+        messageList[index] = message
+    }
+    
+    
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -56,9 +56,9 @@ final class CustomTagContentCell: UICollectionViewCell {
         }
     }
     
-    func configureAllButtonsState(_ state: Bool) {
-        viewModel.updateSubmitButtonState(state)
-        tagCollectionView.isUserInteractionEnabled = state
+    func configureButtonsState(_ state: (Bool, Bool)) {
+        viewModel.updateSubmitButtonState(state.0)
+        tagCollectionView.isUserInteractionEnabled = state.1
     }
     
     // MARK: Private
@@ -127,7 +127,6 @@ final class CustomTagContentCell: UICollectionViewCell {
             }
             
             self.viewModel.submitSelectedTags(selectedList)
-            self.viewModel.updateSubmitButtonState(false)
         }
         submitKeywordButton.addAction(buttonAction, for: .touchUpInside)
     }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -186,10 +186,11 @@ extension CustomTagContentCell: UICollectionViewDataSource {
     fileprivate enum Section: Int {
         case location
         case theme
+        case keyword
     }
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 2
+        return 3
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -197,9 +198,11 @@ extension CustomTagContentCell: UICollectionViewDataSource {
         
         switch section {
         case .location:
-            return viewModel.locationTagListCount
+            return viewModel.locationTagList.count
         case .theme:
-            return viewModel.themeTagListCount
+            return viewModel.themeTagList.count
+        case .keyword:
+            return viewModel.keywordTagList.count
         }
     }
     
@@ -216,6 +219,8 @@ extension CustomTagContentCell: UICollectionViewDataSource {
                 cell.configure(tag: viewModel.locationTagList[indexPath.item])
             case .theme:
                 cell.configure(tag: viewModel.themeTagList[indexPath.item])
+            case .keyword:
+                cell.configure(tag: viewModel.keywordTagList[indexPath.item])
             }
         }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -56,9 +56,9 @@ final class CustomTagContentCell: UICollectionViewCell {
         }
     }
     
-    func configureButtonsState(_ state: (Bool, Bool)) {
-        viewModel.updateSubmitButtonState(state.0)
-        tagCollectionView.isUserInteractionEnabled = state.1
+    func configureButtonsState(_ state: TagMessageInteractionState) {
+        viewModel.updateSubmitButtonState(state.submitButtonState)
+        tagCollectionView.isUserInteractionEnabled = state.interactionState
     }
     
     // MARK: Private

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -313,8 +313,9 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         let messageLabelHeight = defaultMessageLabel.frame.height
         let tagCollectionViewContentHeight = tagCollectionViewLayout.totalHeight
         let submitKeywordButtonHeight = submitKeywordButton.frame.height
+        let accuracyLimit = 16.0
         
-        return tagCollectionViewContentHeight + messageLabelHeight + submitKeywordButtonHeight
+        return tagCollectionViewContentHeight + messageLabelHeight + submitKeywordButtonHeight - accuracyLimit
     }
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -198,11 +198,11 @@ extension CustomTagContentCell: UICollectionViewDataSource {
         
         switch section {
         case .location:
-            return viewModel.locationTagList.count
+            return viewModel.locationTags.count
         case .theme:
-            return viewModel.themeTagList.count
+            return viewModel.themeTags.count
         case .keyword:
-            return viewModel.keywordTagList.count
+            return viewModel.keywordTags.count
         }
     }
     
@@ -216,11 +216,11 @@ extension CustomTagContentCell: UICollectionViewDataSource {
         if let section = Section(rawValue: indexPath.section) {
             switch section {
             case .location:
-                cell.configure(tag: viewModel.locationTagList[indexPath.item])
+                cell.configure(tag: viewModel.locationTags[indexPath.item])
             case .theme:
-                cell.configure(tag: viewModel.themeTagList[indexPath.item])
+                cell.configure(tag: viewModel.themeTags[indexPath.item])
             case .keyword:
-                cell.configure(tag: viewModel.keywordTagList[indexPath.item])
+                cell.configure(tag: viewModel.keywordTags[indexPath.item])
             }
         }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -58,7 +58,7 @@ final class CustomTagContentCell: UICollectionViewCell {
     
     func configureButtonsState(_ state: TagMessageInteractionState) {
         viewModel.updateSubmitButtonState(state.submitButtonState)
-        tagCollectionView.isUserInteractionEnabled = state.interactionState
+        tagCollectionView.isUserInteractionEnabled = state.tagCollectionViewCellInteractionState
     }
     
     // MARK: Private

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -312,6 +312,9 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         let messageLabelHeight = defaultMessageLabel.frame.height
         let tagCollectionViewContentHeight = tagCollectionViewLayout.totalHeight
         let submitKeywordButtonHeight = submitKeywordButton.frame.height
+        // 2개의 섹션으로 사이즈 측정시엔 문제가없었는데, 3개의 섹션을 활용하였을 때, tagCollectionViewContentHeight에서 16.0 가량의 오차가 발생하였습니다.
+        // 정확한 원인은 아직 파악하지 못하였습니다. 해결이 필요 할 것 같습니다.
+        // 현재는 임시방편으로 -16.0으로 계산되도록 구현해두었습니다.
         let accuracyLimit = 16.0
         
         return tagCollectionViewContentHeight + messageLabelHeight + submitKeywordButtonHeight - accuracyLimit

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -56,7 +56,7 @@ final class CustomTagContentCell: UICollectionViewCell {
         }
     }
     
-    func configureButtonsState(_ state: Bool) {
+    func configureAllButtonsState(_ state: Bool) {
         viewModel.updateSubmitButtonState(state)
         tagCollectionView.isUserInteractionEnabled = state
     }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagMessageInteractionState.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagMessageInteractionState.swift
@@ -9,10 +9,10 @@ import Foundation
 
 struct TagMessageInteractionState {
     private (set) var submitButtonState: Bool
-    private (set) var interactionState: Bool
+    private (set) var tagCollectionViewCellInteractionState: Bool
     
     init(submitButtonState: Bool = false, interactionState: Bool = true) {
         self.submitButtonState = submitButtonState
-        self.interactionState = interactionState
+        self.tagCollectionViewCellInteractionState = interactionState
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagMessageInteractionState.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagMessageInteractionState.swift
@@ -1,0 +1,18 @@
+//
+//  TagMessageInteractionState.swift
+//  TravelGenie
+//
+//  Created by 서현웅 on 2023/09/15.
+//
+
+import Foundation
+
+struct TagMessageInteractionState {
+    var submitButtonState: Bool
+    var interactionState: Bool
+    
+    init(submitButtonState: Bool = false, interactionState: Bool = true) {
+        self.submitButtonState = submitButtonState
+        self.interactionState = interactionState
+    }
+}

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagMessageInteractionState.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagMessageInteractionState.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct TagMessageInteractionState {
-    var submitButtonState: Bool
-    var interactionState: Bool
+    private (set) var submitButtonState: Bool
+    private (set) var interactionState: Bool
     
     init(submitButtonState: Bool = false, interactionState: Bool = true) {
         self.submitButtonState = submitButtonState

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagStorage.swift
@@ -9,6 +9,8 @@ import Foundation
 
 final class TagStorage {
     
+    var didChangeTags: (() -> Void)?
+    
     var count: Int {
         return tags.count
     }
@@ -25,7 +27,12 @@ final class TagStorage {
         return tags.filter { $0.category == .keyword }
     }
     
-    private var tags = [Tag]()
+    private var tags = [Tag]() {
+        didSet {
+            didChangeTags?()
+        }
+    }
+    
     private var selectedTags: [Tag] {
         return tags.filter { $0.isSelected == true }
     }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagStorage.swift
@@ -21,6 +21,10 @@ final class TagStorage {
         return tags.filter { $0.category == .theme }
     }
     
+    var keywordTags: [Tag] {
+        return tags.filter { $0.category == .keyword }
+    }
+    
     private var tags = [Tag]()
     private var selectedTags: [Tag] {
         return tags.filter { $0.isSelected == true }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagView/LeftAlignedCollectionViewFlowLayout.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagView/LeftAlignedCollectionViewFlowLayout.swift
@@ -18,7 +18,9 @@ class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
         var leftMargin = sectionInset.left
         var maxY: CGFloat = originAttributes.first?.frame.origin.y ?? 0
         
-        let adjustAttributes = originAttributes.map { layoutAttribute -> UICollectionViewLayoutAttributes in
+        let adjustAttributes = originAttributes.compactMap { originalAttribute -> UICollectionViewLayoutAttributes? in
+            guard let layoutAttribute = originalAttribute.copy() as? UICollectionViewLayoutAttributes else { return nil }
+            
             let isCell = layoutAttribute.representedElementCategory == .cell
             let isHeader = layoutAttribute.representedElementCategory == .supplementaryView
             

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -73,7 +73,7 @@ class ChatInterfaceViewController: MessagesViewController {
                 let cell = messagesCollectionView.dequeueReusableCell(CustomTagContentCell.self, for: indexPath)
                 cell.sizeDelegate = self
                 cell.configure(with: message)
-                cell.configureButtonsState(chatInterfaceViewModel.tagCellInteractionStates)
+                cell.configureButtonsState(chatInterfaceViewModel.tagMessageInteractionState)
                 return cell
             } else if item is [RecommendationItem] {
                 let cell = messagesCollectionView.dequeueReusableCell(RecommendationCell.self, for: indexPath)
@@ -109,7 +109,7 @@ class ChatInterfaceViewController: MessagesViewController {
             }
         }
         
-        chatInterfaceViewModel.didChangeTagCellInteractionStates = { [weak self] in
+        chatInterfaceViewModel.didChangeTagMessageInteractionState = { [weak self] in
             guard let tagMessageIndex = self?.chatInterfaceViewModel.messageStorage.findTagMessageIndex() else {
                 print("MessageStorage에서 TagMessage를 찾지못헀음")
                 return

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -73,7 +73,7 @@ class ChatInterfaceViewController: MessagesViewController {
                 let cell = messagesCollectionView.dequeueReusableCell(CustomTagContentCell.self, for: indexPath)
                 cell.sizeDelegate = self
                 cell.configure(with: message)
-                cell.configureButtonsState(chatInterfaceViewModel.tagCellButtonState)
+                cell.configureButtonsState(chatInterfaceViewModel.tagCellInteractionStates)
                 return cell
             } else if item is [RecommendationItem] {
                 let cell = messagesCollectionView.dequeueReusableCell(RecommendationCell.self, for: indexPath)
@@ -109,7 +109,7 @@ class ChatInterfaceViewController: MessagesViewController {
             }
         }
         
-        chatInterfaceViewModel.didChangeTagCellButtonState = { [weak self] state in
+        chatInterfaceViewModel.didChangeTagCellInteractionStates = { [weak self] in
             guard let tagMessageIndex = self?.chatInterfaceViewModel.messageStorage.findTagMessageIndex() else {
                 print("MessageStorage에서 TagMessage를 찾지못헀음")
                 return

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -98,7 +98,7 @@ class ChatInterfaceViewController: MessagesViewController {
             }
         }
         
-        chatInterfaceViewModel.didChangeUploadButtonState = { [weak self] in
+        chatInterfaceViewModel.disabledUploadButtonState = { [weak self] in
             let uploadButtonCellSectionIndex = MessagesDefaultSection.uploadButtonMessage.rawValue
             let indexSet = IndexSet(integer: uploadButtonCellSectionIndex)
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -98,7 +98,7 @@ class ChatInterfaceViewController: MessagesViewController {
             }
         }
         
-        chatInterfaceViewModel.didChangeUploadButtonState = { [weak self] state in
+        chatInterfaceViewModel.didChangeUploadButtonState = { [weak self] in
             let uploadButtonCellSectionIndex = MessagesDefaultSection.uploadButtonMessage.rawValue
             let indexSet = IndexSet(integer: uploadButtonCellSectionIndex)
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -10,7 +10,7 @@ final class ChatInterfaceViewModel {
     let messageStorage: MessageStorage = MessageStorage()
     var didChangeMessageList: (() -> Void)?
     var didChangeUploadButtonState: ((Bool) -> Void)?
-    var didChangeTagCellButtonState: ((Bool) -> Void)?
+    var didChangeTagCellInteractionStates: (() -> Void)?
     
     private (set) var uploadButtonState: Bool = true {
         didSet {
@@ -18,9 +18,9 @@ final class ChatInterfaceViewModel {
         }
     }
     
-    private (set) var tagCellButtonState: Bool = true {
+    private (set) var tagCellInteractionStates = (submitButtonState: false, interaction: true) {
         didSet {
-            didChangeTagCellButtonState?(tagCellButtonState)
+            didChangeTagCellInteractionStates?()
         }
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -9,12 +9,12 @@ final class ChatInterfaceViewModel {
     
     let messageStorage: MessageStorage = MessageStorage()
     var didChangeMessageList: (() -> Void)?
-    var didChangeUploadButtonState: ((Bool) -> Void)?
+    var didChangeUploadButtonState: (() -> Void)?
     var didChangeTagCellInteractionStates: (() -> Void)?
     
     private (set) var uploadButtonState: Bool = true {
         didSet {
-            didChangeUploadButtonState?(uploadButtonState)
+            didChangeUploadButtonState?()
         }
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -63,7 +63,7 @@ extension ChatInterfaceViewModel: ButtonStateDelegate {
         uploadButtonState = isEnabled
     }
     
-    func setTagCellButtonState(submitButtonState: Bool, interactionState: Bool) {
+    func setTagMessageInteractionState(submitButtonState: Bool, interactionState: Bool) {
         let state = TagMessageInteractionState(submitButtonState: submitButtonState, interactionState: interactionState)
         
         tagMessageInteractionState = state

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -49,6 +49,10 @@ extension ChatInterfaceViewModel: MessageStorageDelegate {
     func fetchMessages() -> [Message] {
         return messageStorage.fetchMessages()
     }
+
+    func updateTagMessage(tagMessage: Message) {
+        messageStorage.updateTagMessage(tagMessage)
+    }
 }
 
 // MARK: ButtonStateDelegate

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -50,8 +50,8 @@ extension ChatInterfaceViewModel: MessageStorageDelegate {
         return messageStorage.fetchMessages()
     }
 
-    func updateTagMessage(tagMessage: Message) {
-        messageStorage.updateTagMessage(tagMessage)
+    func updateTagMessage(selectedTags: [Tag]) {
+        messageStorage.updateTagMessage(selectedTags)
     }
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -63,7 +63,7 @@ extension ChatInterfaceViewModel: ButtonStateDelegate {
         uploadButtonState = isEnabled
     }
     
-    func setTagCellButtonState(_ isEnabled: Bool) {
-        tagCellButtonState = isEnabled
+    func setTagCellButtonState(submitButtonState: Bool, interactionState: Bool) {
+        tagCellInteractionStates = (submitButtonState, interactionState)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -9,12 +9,12 @@ final class ChatInterfaceViewModel {
     
     let messageStorage: MessageStorage = MessageStorage()
     var didChangeMessageList: (() -> Void)?
-    var didChangeUploadButtonState: (() -> Void)?
+    var disabledUploadButtonState: (() -> Void)?
     var didChangeTagCellInteractionStates: (() -> Void)?
     
     private (set) var uploadButtonState: Bool = true {
         didSet {
-            didChangeUploadButtonState?()
+            disabledUploadButtonState?()
         }
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -10,7 +10,7 @@ final class ChatInterfaceViewModel {
     let messageStorage: MessageStorage = MessageStorage()
     var didChangeMessageList: (() -> Void)?
     var disabledUploadButtonState: (() -> Void)?
-    var didChangeTagCellInteractionStates: (() -> Void)?
+    var didChangeTagMessageInteractionState: (() -> Void)?
     
     private (set) var uploadButtonState: Bool = true {
         didSet {
@@ -18,9 +18,9 @@ final class ChatInterfaceViewModel {
         }
     }
     
-    private (set) var tagCellInteractionStates = (submitButtonState: false, interaction: true) {
+    private (set) var tagMessageInteractionState = TagMessageInteractionState() {
         didSet {
-            didChangeTagCellInteractionStates?()
+            didChangeTagMessageInteractionState?()
         }
     }
     
@@ -64,6 +64,8 @@ extension ChatInterfaceViewModel: ButtonStateDelegate {
     }
     
     func setTagCellButtonState(submitButtonState: Bool, interactionState: Bool) {
-        tagCellInteractionStates = (submitButtonState, interactionState)
+        let state = TagMessageInteractionState(submitButtonState: submitButtonState, interactionState: interactionState)
+        
+        tagMessageInteractionState = state
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -17,7 +17,7 @@ protocol MessageStorageDelegate: AnyObject {
 
 protocol ButtonStateDelegate: AnyObject {
     func setUploadButtonState(_ isEnabled: Bool)
-    func setTagCellButtonState(_ isEnabled: Bool)
+    func setTagCellButtonState(submitButtonState: Bool, interactionState: Bool)
 }
 
 final class ChatViewModel {

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -192,7 +192,7 @@ final class ChatViewModel {
         group.notify(queue: .global(qos: .userInteractive)) { [weak self] in
             guard let self else { return }
             
-            self.visionResultProcessor.getSixMostConfidentTranslatedTags() { [weak self] in
+            self.visionResultProcessor.getFourMostConfidentTranslatedTags() { [weak self] in
                 guard let self else { return }
                 let defaultTags = self.makeDefaultTags()
                 let appendedTags = defaultTags + $0

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -402,7 +402,7 @@ final class ChatViewModel {
         
         self.selectedTags = selectedTags
         updateTagMessageSelectedState(selectedTags)
-        buttonStateDelegate?.setTagCellButtonState(false)
+        buttonStateDelegate?.setTagCellButtonState(submitButtonState: false, interactionState: false)
         
         let tagText = selectedTags.map { $0.value }.joined(separator: ", ")
         sendSelectedTags(tagText)

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -17,7 +17,7 @@ protocol MessageStorageDelegate: AnyObject {
 
 protocol ButtonStateDelegate: AnyObject {
     func setUploadButtonState(_ isEnabled: Bool)
-    func setTagCellButtonState(submitButtonState: Bool, interactionState: Bool)
+    func setTagMessageInteractionState(submitButtonState: Bool, interactionState: Bool)
 }
 
 final class ChatViewModel {
@@ -402,7 +402,7 @@ final class ChatViewModel {
         
         self.selectedTags = selectedTags
         updateTagMessageSelectedState(selectedTags)
-        buttonStateDelegate?.setTagCellButtonState(submitButtonState: false, interactionState: false)
+        buttonStateDelegate?.setTagMessageInteractionState(submitButtonState: false, interactionState: false)
         
         let tagText = selectedTags.map { $0.value }.joined(separator: ", ")
         sendSelectedTags(tagText)

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -12,7 +12,7 @@ import OpenAISwift
 protocol MessageStorageDelegate: AnyObject {
     func insert(message: Message)
     func fetchMessages() -> [Message]
-    func updateTagMessage(tagMessage: Message)
+    func updateTagMessage(selectedTags: [Tag])
 }
 
 protocol ButtonStateDelegate: AnyObject {
@@ -408,10 +408,8 @@ final class ChatViewModel {
         sendSelectedTags(tagText)
     }
     
-    private func updateTagMessageSelectedState(_ tags: [Tag]) {
-        let tagMessage = createTagMessage(from: tags)
-        
-        messageStorageDelegate?.updateTagMessage(tagMessage: tagMessage)
+    private func updateTagMessageSelectedState(_ selectedTags: [Tag]) {
+        messageStorageDelegate?.updateTagMessage(selectedTags: selectedTags)
     }
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -206,7 +206,15 @@ final class ChatViewModel {
     private func makeDefaultTags() -> [Tag] {
         return [
             Tag(category: .location, value: "국내"),
-            Tag(category: .location, value: "해외")]
+            Tag(category: .location, value: "해외"),
+            
+            Tag(category: .theme, value: "관광"),
+            Tag(category: .theme, value: "휴식"),
+            Tag(category: .theme, value: "음식"),
+            Tag(category: .theme, value: "역사탐방"),
+            Tag(category: .theme, value: "액티비티")
+            
+        ]
     }
 
     private func convertToBase64(from data: Data) -> String? {

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -401,9 +401,17 @@ final class ChatViewModel {
         guard let selectedTags = notification.userInfo?[NotificationKey.selectedTags] as? [Tag] else { return }
         
         self.selectedTags = selectedTags
+        updateTagMessageSelectedState(selectedTags)
+        buttonStateDelegate?.setTagCellButtonState(false)
         
         let tagText = selectedTags.map { $0.value }.joined(separator: ", ")
         sendSelectedTags(tagText)
+    }
+    
+    private func updateTagMessageSelectedState(_ tags: [Tag]) {
+        let tagMessage = createTagMessage(from: tags)
+        
+        messageStorageDelegate?.updateTagMessage(tagMessage: tagMessage)
     }
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -204,17 +204,10 @@ final class ChatViewModel {
     }
     
     private func makeDefaultTags() -> [Tag] {
-        return [
-            Tag(category: .location, value: "국내"),
-            Tag(category: .location, value: "해외"),
-            
-            Tag(category: .theme, value: "관광"),
-            Tag(category: .theme, value: "휴식"),
-            Tag(category: .theme, value: "음식"),
-            Tag(category: .theme, value: "역사탐방"),
-            Tag(category: .theme, value: "액티비티")
-            
-        ]
+        let locationTags = ["국내", "해외"].map { Tag(category: .location, value: $0) }
+        let themeTags = ["관광", "휴양", "음식", "역사탐방", "액티비티"].map { Tag(category: .theme, value: $0) }
+        
+        return locationTags + themeTags
     }
 
     private func convertToBase64(from data: Data) -> String? {

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -12,6 +12,7 @@ import OpenAISwift
 protocol MessageStorageDelegate: AnyObject {
     func insert(message: Message)
     func fetchMessages() -> [Message]
+    func updateTagMessage(tagMessage: Message)
 }
 
 protocol ButtonStateDelegate: AnyObject {

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
@@ -9,15 +9,15 @@ import Foundation
 
 final class CustomTagContentCellViewModel {
     
-    var locationTagList: [Tag] {
+    var locationTags: [Tag] {
         return tagStorage.locationTags
     }
     
-    var themeTagList: [Tag] {
+    var themeTags: [Tag] {
         return tagStorage.themeTags
     }
     
-    var keywordTagList: [Tag] {
+    var keywordTags: [Tag] {
         return tagStorage.keywordTags
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
@@ -89,6 +89,19 @@ final class CustomTagContentCellViewModel {
     
     // MARK: Private
     
+    private func bind() {
+        tagStorage.didChangeTags = { [weak self] in
+            self?.handleTagSelectionChange()
+        }
+    }
+    
+    private func handleTagSelectionChange() {
+        guard let selectedTagsCount = self.getSelectedTags()?.count else { return }
+        let hasRequiredTagCount = selectedTagsCount >= 2
+        
+        self.updateSubmitButtonState(hasRequiredTagCount)
+    }
+    
     private func calculateSizeForCharacters(count: CGFloat) -> CGSize {
         let additionalWidthForOneCharacterSize: CGFloat = 13.0
         let defaultHeight: CGFloat = 47.0

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
@@ -75,6 +75,11 @@ final class CustomTagContentCellViewModel {
             let numberOfCharactersInTag = CGFloat(tagStorage.themeTags[indexPath.item].value.count)
             
             return calculateSizeForCharacters(count: numberOfCharactersInTag)
+            
+        case 2:
+            let numberOfCharactersInTag = CGFloat(tagStorage.keywordTags[indexPath.item].value.count)
+            
+            return calculateSizeForCharacters(count: numberOfCharactersInTag)
         default:
             break
         }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
@@ -35,6 +35,12 @@ final class CustomTagContentCellViewModel {
         }
     }
     
+    // MARK: Lifecycle
+    
+    init() {
+        bind()
+    }
+    
     // MARK: Internal
     
     func insertTags(tags: [Tag]) {
@@ -43,7 +49,6 @@ final class CustomTagContentCellViewModel {
     
     func getSelectedTags() -> [Tag]? {
         guard let isSelectedTags = tagStorage.getSelectedTags() else {
-            print("선택된 태그없음")
             return nil
         }
         

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
@@ -29,7 +29,7 @@ final class CustomTagContentCellViewModel {
 
     private let tagStorage: TagStorage = TagStorage()
 
-    private var submitButtonState: Bool = true {
+    private var submitButtonState: Bool = false {
         didSet {
             didTapSubmitButton?(submitButtonState)
         }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
@@ -9,14 +9,6 @@ import Foundation
 
 final class CustomTagContentCellViewModel {
     
-    var locationTagListCount: Int {
-        return tagStorage.locationTags.count
-    }
-    
-    var themeTagListCount: Int {
-        return tagStorage.themeTags.count
-    }
-    
     var locationTagList: [Tag] {
         return tagStorage.locationTags
     }
@@ -25,8 +17,12 @@ final class CustomTagContentCellViewModel {
         return tagStorage.themeTags
     }
     
+    var keywordTagList: [Tag] {
+        return tagStorage.keywordTags
+    }
+    
     var sectionsHeaderTexts: [String] {
-        return ["✈️지역", "⛵️테마"]
+        return ["✈️지역", "⛵️테마", "🔑️키워드"]
     }
     
     var didTapSubmitButton: ((Bool) -> Void)?

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/VisionResultProcessor.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/VisionResultProcessor.swift
@@ -32,7 +32,7 @@ final class VisionResultProcessor {
         visionResults.landmarks.append(contentsOf: landmarks)
     }
     
-    func getSixMostConfidentTranslatedTags(completion: @escaping ([Tag]) -> Void) {
+    func getFourMostConfidentTranslatedTags(completion: @escaping ([Tag]) -> Void) {
         let sortedAndJoinedKeywords = keywordsOrderedByConfidence().joined(separator: ",")
         
         translate(keyword: sortedAndJoinedKeywords) { [weak self] result in
@@ -40,8 +40,8 @@ final class VisionResultProcessor {
             
             var uniqueValues = self.removeDuplicateValues(text: result)
             
-            if uniqueValues.count > 6 {
-                uniqueValues = Array(uniqueValues.prefix(6))
+            if uniqueValues.count > 4 {
+                uniqueValues = Array(uniqueValues.prefix(4))
             }
             
             let topSixTags = self.convertToTags(texts: uniqueValues)

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/VisionResultProcessor.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/VisionResultProcessor.swift
@@ -78,6 +78,6 @@ final class VisionResultProcessor {
     }
     
     private func convertToTags(texts: [String]) -> [Tag] {
-        return texts.map { Tag(category: .theme, value: $0) }
+        return texts.map { Tag(category: .keyword, value: $0) }
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/ChatHistory/ViewModel/ChatHistoryViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/ChatHistory/ViewModel/ChatHistoryViewModel.swift
@@ -25,6 +25,6 @@ final class ChatHistoryViewModel {
     
     func deactivateButtons() {
         buttonStateDelegate?.setUploadButtonState(false)
-        buttonStateDelegate?.setTagCellButtonState(false)
+        buttonStateDelegate?.setTagCellButtonState(submitButtonState: false, interactionState: false)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/ChatHistory/ViewModel/ChatHistoryViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/ChatHistory/ViewModel/ChatHistoryViewModel.swift
@@ -25,6 +25,6 @@ final class ChatHistoryViewModel {
     
     func deactivateButtons() {
         buttonStateDelegate?.setUploadButtonState(false)
-        buttonStateDelegate?.setTagCellButtonState(submitButtonState: false, interactionState: false)
+        buttonStateDelegate?.setTagMessageInteractionState(submitButtonState: false, interactionState: false)
     }
 }


### PR DESCRIPTION
Resolves #74 #86 

**태그 제출 후에도 SubmitKeywordButton이 동작하는 버그 수정**
- tag를 제출했음에도 tag가 선택되거나 submitKewordButton이 계속 동작하는 버그를 제거

**태그 제출 후에 MessageStorage가 변경사항을 반영하지 못하던 버그 수정**
- 기존 코드에선 tag를 제출한 후에도 MessageStorage가 이를 반영하지 못하였었습니다.
- 따라서, 해당 태그셀이 리로드되면 선택사항을 반영하지 못하고 모든 선택이 제거되어버리는 현상이 있었고 이를 수정

**TagItem의 category로 keword를 추가** 
- defaultKeword로 5가지를 포함하여 [관광], [음식], [역사탐방], [휴양], [액티비티]를 포함하도록 수정
- TagCell을 Self-Size하는 로직을 일부조정

**외부에서 TagCell의 버튼을 비활성하는 로직을 수정** 
- buttonStateDelegate의 함수가 인자로 interaction과 submitButton의 상태를 각각받도록 수정

--- 
작은 업무였는데
기존 코드에 버그가 있어서 원인을 찾고 고민하느라 좀 걸렸네요
이 코드가 머지된 이후에 [영문,숫자]에 사이징 할 수 있도록 코드 수정해보겠습니당