### PR TITLE
Feature/51/RecommendationMessage 이후, additionalQuestionMessage가 추가되도록 구현

### DIFF
--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/RecommendationCell/RecommendationCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/RecommendationCell/RecommendationCell.swift
@@ -57,6 +57,7 @@ final class RecommendationCell: UICollectionViewCell {
         recommendationCollectionView.dataSource = self
         recommendationCollectionView.backgroundColor = .clear
         recommendationCollectionView.collectionViewLayout = layout
+        recommendationCollectionView.showsHorizontalScrollIndicator = false
         recommendationCollectionView.register(
             AvatarHeaderView.self,
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -295,6 +295,7 @@ final class ChatViewModel {
             let message = Message(recommendations: self.recommendationItems)
             removeLoadingMessage()
             insertMessage(message)
+            insertAdditionalQuestionMessage()
         }
     }
     
@@ -332,6 +333,12 @@ final class ChatViewModel {
     
     private func createLoadingMessage() -> Message {
         return Message(sender: ai, messageId: "loading", sentDate: Date())
+    }
+    
+    private func insertAdditionalQuestionMessage() {
+        let additionalQuestionTextMessage = createTextMessage(with: "더 궁금한 점이 있으신가요?", sender: ai)
+        
+        insertMessage(additionalQuestionTextMessage)
     }
     
     // MARK: OpenAI


### PR DESCRIPTION
Resolves #92 

**additionalQuestionMessage 관련**
- RecommendationMessage가 추가된 이후, addtionalQuestionMessage가 추가되도록 수정하였습니다.
- 이는 아래 시점에 추가되도록 구현되었습니다.

```swift
private func insertRecommendationMessage(with result: OpenAIRecommendation) {
    insertLoadingMessage()
    
    let items = result.recommendationItems
    let group = DispatchGroup()
    
    for item in items {
        group.enter()
        createRecommendationItem(with: item) { [weak self] recommendationItem in
            self?.recommendationItems.append(recommendationItem)
            group.leave()
        }
    }
    
    group.notify(queue: .main) { [weak self] in
        guard let self else { return }
        let message = Message(recommendations: self.recommendationItems)
        removeLoadingMessage()
        insertMessage(message)
        insertAdditionalQuestionMessage()
    }
}
```

**recommendationCollectionView의 horizontal Scroll Indicator 비활성화**
- horizontal 스크롤인디케이터가 비활성화 되도록 구현 하였습니다