### PR TITLE
Refactor/54/텍스트메시지 셀 사이즈 계산 로직, 텍스트 line height 계산 로직 리팩토링

### DIFF
--- a/TravelGenie/TravelGenie/Extensions/NSMutableAttributedString+text.swift
+++ b/TravelGenie/TravelGenie/Extensions/NSMutableAttributedString+text.swift
@@ -9,18 +9,17 @@ import UIKit
 
 extension NSMutableAttributedString {
     func text(_ value: String, font: Font, color: UIColor) -> NSMutableAttributedString {
-        let style = NSMutableParagraphStyle()
         let fontSize: CGFloat = font.fontSize
-        let lineHeight: CGFloat = font.lineHeight
-        let font: UIFont = .systemFont(ofSize: fontSize, weight: font.weight)
-        style.minimumLineHeight = lineHeight
-        style.maximumLineHeight = lineHeight
+        let systemFont: UIFont = .systemFont(ofSize: fontSize, weight: font.weight)
+                
+        let style = NSMutableParagraphStyle()
+        let lineSpacing: CGFloat = font.lineSpacing
+        style.lineSpacing = lineSpacing
         
         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: color,
+            .font: systemFont,
             .paragraphStyle: style,
-            .font: font,
-            .baselineOffset: (lineHeight - font.lineHeight) / 4,
+            .foregroundColor: color,
         ]
         
         self.append(NSAttributedString(string: value, attributes: attributes))
@@ -29,19 +28,19 @@ extension NSMutableAttributedString {
     }
     
     func messageText(_ value: String, font: Font, sender: Sender) -> NSMutableAttributedString {
-        let style = NSMutableParagraphStyle()
         let fontSize: CGFloat = font.fontSize
-        let lineHeight: CGFloat = font.lineHeight
-        let font: UIFont = .systemFont(ofSize: fontSize, weight: font.weight)
-        let fontColor: UIColor = sender.displayName == "ai" ? .black : .white
-        style.minimumLineHeight = lineHeight
-        style.maximumLineHeight = lineHeight
+        let systemFont: UIFont = .systemFont(ofSize: fontSize, weight: font.weight)
+                
+        let style = NSMutableParagraphStyle()
+        let lineSpacing: CGFloat = font.lineSpacing
+        style.lineSpacing = lineSpacing
         
+        let fontColor: UIColor = sender.displayName == "ai" ? .black : .white
+
         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: fontColor,
+            .font: systemFont,
             .paragraphStyle: style,
-            .font: font,
-            .baselineOffset: (lineHeight - font.lineHeight) / 4,
+            .foregroundColor: fontColor,
         ]
         
         self.append(NSAttributedString(string: value, attributes: attributes))

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/SizeCalculator/AttributedTextCellSizeCalculator.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/SizeCalculator/AttributedTextCellSizeCalculator.swift
@@ -10,24 +10,6 @@ import UIKit
 
 final class AttributedTextCellSizeCalculator: MessageSizeCalculator {
     
-    override func configure(attributes: UICollectionViewLayoutAttributes) {
-        super.configure(attributes: attributes)
-        guard let attributes = attributes as? MessagesCollectionViewLayoutAttributes else { return }
-        
-        attributes.messageLabelInsets = UIEdgeInsets(top: 8, left: 20, bottom: 12, right: 20)
-    }
-    
-    override func cellContentHeight(
-        for message: MessageType,
-        at indexPath: IndexPath)
-        -> CGFloat
-    {
-        let messageContainerHeight = messageContainerSize(for: message, at: indexPath).height
-        let avatarHeight = avatarSize(for: message, at: indexPath).height
-        
-        return max(messageContainerHeight, avatarHeight)
-    }
-    
     override func messageContainerMaxWidth(
         for message: MessageType,
         at indexPath: IndexPath)
@@ -54,24 +36,22 @@ final class AttributedTextCellSizeCalculator: MessageSizeCalculator {
         return CGSize(width: width, height: height)
     }
     
-    func messageLabelSize(
+    override func configure(attributes: UICollectionViewLayoutAttributes) {
+        super.configure(attributes: attributes)
+        guard let attributes = attributes as? MessagesCollectionViewLayoutAttributes else { return }
+        
+        attributes.messageLabelInsets = UIEdgeInsets(top: 8, left: 20, bottom: 12, right: 20)
+    }
+    
+    override func cellContentHeight(
         for message: MessageType,
         at indexPath: IndexPath)
-        -> CGSize
+        -> CGFloat
     {
-        let attributedText: NSAttributedString
-        let textMessageKind = message.kind
+        let messageContainerHeight = messageContainerSize(for: message, at: indexPath).height
+        let avatarHeight = avatarSize(for: message, at: indexPath).height
         
-        switch textMessageKind {
-        case .attributedText(let text):
-            attributedText = text
-        default:
-            fatalError("messageLabelSize received unhandled MessageDataType: \(message.kind)")
-        }
-        
-        let maxWidth = messageContainerMaxWidth(for: message, at: indexPath) - 20 - 20
-        
-        return attributedText.size(consideringWidth: maxWidth)
+        return max(messageContainerHeight, avatarHeight)
     }
     
     override func messageContainerPadding(for message: MessageType) -> UIEdgeInsets {
@@ -107,5 +87,25 @@ final class AttributedTextCellSizeCalculator: MessageSizeCalculator {
         avatarLeadingTrailingPadding = 12
         
         return isFromCurrentSender ? AvatarPosition(horizontal: .cellTrailing, vertical: .cellTop) : AvatarPosition(horizontal: .cellLeading, vertical: .cellTop)
+    }
+    
+    func messageLabelSize(
+        for message: MessageType,
+        at indexPath: IndexPath)
+        -> CGSize
+    {
+        let attributedText: NSAttributedString
+        let textMessageKind = message.kind
+        
+        switch textMessageKind {
+        case .attributedText(let text):
+            attributedText = text
+        default:
+            fatalError("messageLabelSize received unhandled MessageDataType: \(message.kind)")
+        }
+        
+        let maxWidth = messageContainerMaxWidth(for: message, at: indexPath) - 20 - 20
+        
+        return attributedText.size(consideringWidth: maxWidth)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/SizeCalculator/AttributedTextCellSizeCalculator.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/SizeCalculator/AttributedTextCellSizeCalculator.swift
@@ -23,24 +23,27 @@ final class AttributedTextCellSizeCalculator: MessageSizeCalculator {
         at indexPath: IndexPath)
         -> CGSize
     {
-        let size = super.messageContainerSize(
-            for: message,
-            at: indexPath)
-        let labelSize = messageLabelSize(
-            for: message,
-            at: indexPath)
-        let selfWidth = labelSize.width + 20 + 20
-        let width = max(selfWidth, size.width)
-        let height = size.height + labelSize.height + 12 + 8
+        let labelSize = messageLabelSize(for: message, at: indexPath)
+        let messageInsets = UIEdgeInsets(
+            top: Design.verticalPadding,
+            left: Design.horizontalPadding,
+            bottom: Design.verticalPadding,
+            right: Design.horizontalPadding)
         
-        return CGSize(width: width, height: height)
+        return CGSize(
+            width: labelSize.width + messageInsets.left + messageInsets.right,
+            height: labelSize.height + messageInsets.top + messageInsets.bottom)
     }
     
     override func configure(attributes: UICollectionViewLayoutAttributes) {
         super.configure(attributes: attributes)
         guard let attributes = attributes as? MessagesCollectionViewLayoutAttributes else { return }
         
-        attributes.messageLabelInsets = UIEdgeInsets(top: 8, left: 20, bottom: 12, right: 20)
+        attributes.messageLabelInsets = UIEdgeInsets(
+            top: Design.verticalPadding,
+            left: Design.horizontalPadding,
+            bottom: Design.verticalPadding,
+            right: Design.horizontalPadding)
     }
     
     override func cellContentHeight(
@@ -103,9 +106,22 @@ final class AttributedTextCellSizeCalculator: MessageSizeCalculator {
         default:
             fatalError("messageLabelSize received unhandled MessageDataType: \(message.kind)")
         }
+
+        let maxWidth = messageContainerMaxWidth(for: message, at: indexPath) - Design.horizontalPadding * 2
+        let constraintBox = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
+        let messageLabelSize = attributedText.boundingRect(
+            with: constraintBox,
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            context: nil)
+            .integral
         
-        let maxWidth = messageContainerMaxWidth(for: message, at: indexPath) - 20 - 20
-        
-        return attributedText.size(consideringWidth: maxWidth)
+        return messageLabelSize.size
+    }
+}
+
+private extension AttributedTextCellSizeCalculator {
+    enum Design {
+        static let horizontalPadding: CGFloat = 20
+        static let verticalPadding: CGFloat = 12
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -136,7 +136,7 @@ class ChatInterfaceViewController: MessagesViewController {
     
     private func customizeMessagesCollectionViewLayout() {
         let layout = messagesCollectionView.collectionViewLayout as? MessagesCollectionViewFlowLayout
-        layout?.sectionInset = UIEdgeInsets(top: 8, left: .zero, bottom: 8, right: .zero)
+        layout?.sectionInset = UIEdgeInsets(top: 0, left: .zero, bottom: 16, right: .zero)
         layout?.setMessageOutgoingAvatarSize(CGSize(width: 0, height: 0))
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
@@ -66,7 +66,7 @@ final class ChatViewController: ChatInterfaceViewController {
     }
     
     private func createBackBarButtonAction() -> UIAction {
-        let backBarButtonImage = UIImage(systemName: "chevron.left")
+        let backBarButtonImage = UIImage(systemName: DesignAssetName.backButtonImage)
         
         return UIAction(image: backBarButtonImage) { [weak self] _ in
             guard let self else { return }

--- a/TravelGenie/TravelGenie/Presentation/ChatHistory/View/ChatHistoryViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/ChatHistory/View/ChatHistoryViewController.swift
@@ -59,7 +59,7 @@ final class ChatHistoryViewController: ChatInterfaceViewController {
     }
     
     private func createBackBarButtonAction() -> UIAction {
-        let backBarButtonImage = UIImage(systemName: "chevron.left")
+        let backBarButtonImage = UIImage(systemName: DesignAssetName.backButtonImage)
         
         return UIAction(image: backBarButtonImage) { [weak self] _ in
             guard let self else { return }

--- a/TravelGenie/TravelGenie/Presentation/Common/DesignAssetName.swift
+++ b/TravelGenie/TravelGenie/Presentation/Common/DesignAssetName.swift
@@ -11,4 +11,5 @@ enum DesignAssetName {
     static let xMarkImage: String = "xmark"
     static let thumbsUpImage: String = "thumbs-up-regular"
     static let thumbsDownImage: String = "thumbs-down-regular"
+    static let backButtonImage: String = "chevron.left"
 }

--- a/TravelGenie/TravelGenie/Presentation/Common/TextAttributeCreator.swift
+++ b/TravelGenie/TravelGenie/Presentation/Common/TextAttributeCreator.swift
@@ -9,18 +9,18 @@ import UIKit
 
 final class TextAttributeCreator {
     
-    static func create(
-        font: Font,
-        color: UIColor)
-        -> [NSAttributedString.Key: Any]
-    {
+    static func create(font: Font, color: UIColor) -> [NSAttributedString.Key: Any] {
         let fontSize: CGFloat = font.fontSize
-        let lineHeight: CGFloat = font.lineHeight
-        let font: UIFont = .systemFont(ofSize: fontSize, weight: font.weight)
+        let systemFont: UIFont = .systemFont(ofSize: fontSize, weight: font.weight)
+                
+        let style = NSMutableParagraphStyle()
+        let lineSpacing: CGFloat = font.lineSpacing
+        style.lineSpacing = lineSpacing
+        
         let attributes: [NSAttributedString.Key: Any] = [
+            .font: systemFont,
+            .paragraphStyle: style,
             .foregroundColor: color,
-            .font: font,
-            .baselineOffset: (lineHeight - font.lineHeight) / 4,
         ]
         
         return attributes

--- a/TravelGenie/TravelGenie/Resources/Font.swift
+++ b/TravelGenie/TravelGenie/Resources/Font.swift
@@ -49,14 +49,14 @@ enum Font {
         }
     }
     
-    var lineHeight: CGFloat {
+    var lineSpacing: CGFloat {
         switch self {
         case .largeTitle:
-            return fontSize * 1.3
+            return 1.3
         case .micro:
-            return fontSize * 1.0
+            return 1.0
         default:
-            return fontSize * 1.5
+            return 1.5
         }
     }
 }


### PR DESCRIPTION
Resolves #108 

### 텍스트메시지 셀 사이즈 계산 로직 리팩토링 (`AttributedTextCellSizeCalculator`)
- 최소 사이즈를 계산할 수 있도록 사이즈 계산 로직을 클래스 내에 직접 구현 (해당 라이브러리의 구현 로직 참고)
- 의미를 알기 어려운 매직넘버를 상수화 해주었습니다.

### 텍스트 line height 계산 로직 리팩토링

피그마에 정의된 Line Height를 기존에는 `NSMutableParagraphStyle`의 `minimumLineHeight`, `maximumLineHeight` 프로퍼티를 이용해 설정하고 있었습니다. 하지만 다음과 같은 문제점이 있었습니다.
  - 텍스트를 정확히 행의 가운데에 위치시키기가 어려움
  - 텍스트가 들어간 메시지 셀의 높이 계산 시, 높이가 디자인에서 요구하는 높이보다 부족하게 계산됨
    - 가장 마지막 줄의 경우 행에 추가 여백 공간이 생기지 않기 때문인 것으로 추정
 
이를 해결하기 위해 `lineHeightMultiple` 프로퍼티를 이용해보려고 했으나, 위와 동일한 문제가 있었습니다.
`lineHeightMultiple` 프로퍼티에 관해 좀 더 알아보는 과정에서 다음 참고 링크를 발견했고, `lineHeightMultiple`과 `lineSpacing`의 차이점을 알 수 있었습니다. [참고 - lineSpacing과 lineHeightMultiple의 비교](https://stackoverflow.com/questions/48793470/when-should-you-use-lineheightmultiple-vs-linespacing)
![image](https://github.com/Team-TravelGenie/TripChat/assets/98260324/24d676f2-101b-4916-9fb5-ac2c1a8a042e)

둘 중 어떤 방식(텍스트가 위에 붙을지, 아래에 붙을지)이 더 적절할 지 확인하고자 피그마 홈페이지에서 피그마의 Line Height의 의미를 찾아보니, 다음과 같았습니다 [링크](https://help.figma.com/hc/en-us/articles/360039956634#spacing). 따라서 `lineSpacing`을 사용해도 괜찮다는 판단을 내리고 `lineSpacing`을 사용해 리팩토링 하였습니다.

### 이외 변경사항
- 뒤로가기 버튼 이름을 `DesignAssetName`에 추가
- `messageCollectionView`의 `sectionInset`: `top`제거, `bottom`에 `top` 값 추가(+)