### PR TITLE
Feature/55/채팅 입력창을 탭 해서 키보드가 올라올 때 메시지를 맨 아래까지 스크롤

### DIFF
--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
@@ -22,6 +22,7 @@ final class ChatViewController: ChatInterfaceViewController {
         chatViewModel.messageStorageDelegate = chatInterfaceViewModel
         chatViewModel.buttonStateDelegate = chatInterfaceViewModel
         chatViewModel.inputBarButtonStateDelegate = self
+        scrollsToLastItemOnKeyboardBeginsEditing = true
     }
     
     required init?(coder: NSCoder) {
@@ -31,9 +32,9 @@ final class ChatViewController: ChatInterfaceViewController {
     // MARK: Override(s)
     
     override func viewDidLoad() {
+        configureMessageInputBar()
         super.viewDidLoad()
         setupNavigation()
-        configureMessageInputBar()
         chatViewModel.setupDefaultSystemMessages()
     }
     
@@ -83,8 +84,7 @@ final class ChatViewController: ChatInterfaceViewController {
         customInputBar.inputBarButtonDelegate = self
         customInputBar.separatorLine.isHidden = true
         customInputBar.delegate = chatViewModel
-        messageInputBar = customInputBar
-        inputBarType = .custom(messageInputBar)
+        inputBarType = .custom(customInputBar)
     }
 }
 


### PR DESCRIPTION
Resolves #100 

채팅 입력창을 탭 해서 키보드가 올라오면 `messageCollectionView`를 맨 아래까지 스크롤하도록 구현
- 라이브러리에 기존 구현된 `scrollsToLastItemOnKeyboardBeginsEditing` 프로퍼티 활용
- `customInputBar`에 해당 액션이 등록되도록 `customInputBar`를 설정, 할당하는 메서드 순서를 `super.viewDidLoad()` 이전으로 변경