### PR TITLE
Fix/56/마지막 메시지가 로딩 메시지일 경우 저장에 실패하는 버그 수정

### DIFF
--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -134,10 +134,17 @@ final class ChatViewModel {
     }
     
     func saveChat() {
-        guard let messages = messageStorageDelegate?.fetchMessages(),
+        guard var messages = messageStorageDelegate?.fetchMessages(),
               isValidChat()
         else { return }
         
+        if let lastMessage = messages.last,
+           lastMessage.messageId == "loading"
+        {
+            messages.removeLast()
+        }
+        
+
         let chat = createChat(with: messages)
         chatUseCase.save(chat: chat) { error in
             print(error?.localizedDescription)


### PR DESCRIPTION
Resolves #109 

- 마지막 메시지가 로딩 메시지일 경우 해당 메시지를 제거한 후 저장