### PR TITLE
Fix/64/스크롤이 되지 않는 문제 해결

### DIFF
--- a/TravelGenie/TravelGenie/Presentation/Home/View/HomeViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Home/View/HomeViewController.swift
@@ -93,7 +93,6 @@ final class HomeViewController: UIViewController {
             contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
             contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
-            contentView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
         ])
         
         planeImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -131,6 +130,7 @@ final class HomeViewController: UIViewController {
         bottomMenuTableView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             bottomMenuTableView.topAnchor.constraint(equalTo: chatButton.bottomAnchor, constant: 52),
+            bottomMenuTableView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -1),
             bottomMenuTableView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             bottomMenuTableView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
         ])


### PR DESCRIPTION
Resolves #127 

- 원인: `contentView` 내부 뷰 중 가장 하단에 위치한 `bottomMenuTableView`의 `bottomAnchor`와 `contentView`의 `bottomAnchor`간의 제약이 없어 `contentView`의 높이를 계산하지 못하고 있었음
- 해결
  - `contentView`의 높이 제약 제거
  - `bottomMenuTableView.bottomAnchor`와 `contentView.bottomAnchor`간 제약 설정