### PR TITLE
Fix/66/messageInputBar의 버튼/텍스트뷰 비활성화 미작동 현상 수정

### DIFF
--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
@@ -127,14 +127,14 @@ extension ChatViewController: CustomInputBarAccessoryViewDelegate {
 
 extension ChatViewController: InputBarStateDelegate {
     func setPhotosButtonState(_ isEnabled: Bool) {
-        guard let inputBar = messageInputBar as? CustomInputBarAccessoryView else { return }
+        guard let inputBar = inputContainerView.subviews.first as? CustomInputBarAccessoryView else { return }
         
         inputBar.updatePhotosButtonState(isEnabled)
     }
     
     func updateInputTextViewState(_ isEditable: Bool) {
-        DispatchQueue.main.async { [weak self] in
-            self?.messageInputBar.inputTextView.isEditable = isEditable
-        }
+        guard let inputBar = inputContainerView.subviews.first as? CustomInputBarAccessoryView else { return }
+        
+        inputBar.updateInputTextViewState(isEditable)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
@@ -32,8 +32,8 @@ final class ChatViewController: ChatInterfaceViewController {
     // MARK: Override(s)
     
     override func viewDidLoad() {
-        configureMessageInputBar()
         super.viewDidLoad()
+        configureMessageInputBar()
         setupNavigation()
         chatViewModel.setupDefaultSystemMessages()
     }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
@@ -127,14 +127,18 @@ extension ChatViewController: CustomInputBarAccessoryViewDelegate {
 
 extension ChatViewController: InputBarStateDelegate {
     func setPhotosButtonState(_ isEnabled: Bool) {
-        guard let inputBar = inputContainerView.subviews.first as? CustomInputBarAccessoryView else { return }
-        
-        inputBar.updatePhotosButtonState(isEnabled)
+        DispatchQueue.main.async { [weak self] in
+            guard let inputBar = self?.inputContainerView.subviews.first as? CustomInputBarAccessoryView else { return }
+            
+            inputBar.updatePhotosButtonState(isEnabled)
+        }
     }
     
     func updateInputTextViewState(_ isEditable: Bool) {
-        guard let inputBar = inputContainerView.subviews.first as? CustomInputBarAccessoryView else { return }
-        
-        inputBar.updateInputTextViewState(isEditable)
+        DispatchQueue.main.async { [weak self] in
+            guard let inputBar = self?.inputContainerView.subviews.first as? CustomInputBarAccessoryView else { return }
+            
+            inputBar.updateInputTextViewState(isEditable)
+        }
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/CustomInputBarAccessoryView.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/CustomInputBarAccessoryView.swift
@@ -37,15 +37,11 @@ final class CustomInputBarAccessoryView: InputBarAccessoryView {
     // MARK: Internal
     
     func updatePhotosButtonState(_ isEnabled: Bool) {
-        DispatchQueue.main.async { [weak self] in
-            self?.photosButton.isEnabled = isEnabled
-        }
+        photosButton.isEnabled = isEnabled
     }
     
     func updateInputTextViewState(_ isEditable: Bool) {
-        DispatchQueue.main.async { [weak self] in
-            self?.inputTextView.isEditable = isEditable
-        }
+        inputTextView.isEditable = isEditable
     }
     
     // MARK: Private

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/CustomInputBarAccessoryView.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/CustomInputBarAccessoryView.swift
@@ -37,7 +37,9 @@ final class CustomInputBarAccessoryView: InputBarAccessoryView {
     // MARK: Internal
     
     func updatePhotosButtonState(_ isEnabled: Bool) {
-        photosButton.isEnabled = isEnabled
+        DispatchQueue.main.async { [weak self] in
+            self?.photosButton.isEnabled = isEnabled
+        }
     }
     
     func updateInputTextViewState(_ isEditable: Bool) {

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/CustomInputBarAccessoryView.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/CustomInputBarAccessoryView.swift
@@ -40,6 +40,12 @@ final class CustomInputBarAccessoryView: InputBarAccessoryView {
         photosButton.isEnabled = isEnabled
     }
     
+    func updateInputTextViewState(_ isEditable: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            self?.inputTextView.isEditable = isEditable
+        }
+    }
+    
     // MARK: Private
     
     private func configureSubviews() {

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -217,7 +217,6 @@ final class ChatViewModel {
                 
                 removeLoadingMessage()
                 insertMessage(tagMessage)
-                updateInputTextViewState(isEditable: false)
             }
         }
     }
@@ -297,7 +296,6 @@ final class ChatViewModel {
             removeLoadingMessage()
             insertMessage(message)
             insertAdditionalQuestionMessage()
-            updateInputTextViewState(isEditable: true)
         }
     }
     


### PR DESCRIPTION
`messageInputBar`의 버튼과 텍스트뷰를 활성화/비활성화 하는 동작이 제대로 수행되지 않고 있었음.
  - 원인: `MessageViewController`의 `messageInputBar` 프로퍼티에 할당된 인스턴스 자체는 변경되지 않고, `inputContainerView`의 subview만 변경되고 있었기 때문
  - 해결: 버튼/텍스트뷰 활성화/비활성화 동작 시, `inputContainerView`의 subview를 확인하여 isEnabled/isEditable 상태를 변경해주도록 수정