### PR TITLE
Feat/68/태그 필터링 기능 구현

### DIFF
--- a/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
@@ -14,8 +14,9 @@ final class VisionResultProcessor {
         var landmarks: [Landmark]
     }
     
-    private var visionResults = VisionResults(keywords: [], landmarks: [])
     private let translateUseCase: TranslateUseCase
+    
+    private var visionResults = VisionResults(keywords: [], landmarks: [])
     
     init(
         translateUseCase: TranslateUseCase = DefaultTranslateUseCase(

--- a/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
@@ -15,6 +15,18 @@ final class VisionResultProcessor {
     }
     
     private let translateUseCase: TranslateUseCase
+    private let keywordsToFilter: [String] = [
+        "Water",
+        "Water resources",
+        "Fluvial landforms of streams",
+        "Body of water",
+        "Natural environment",
+        "Watercourse",
+        "Landscape",
+        "Atmosphere",
+        "World",
+        "Groundcover",
+    ]
     
     private var visionResults = VisionResults(keywords: [], landmarks: [])
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
@@ -46,9 +46,10 @@ final class VisionResultProcessor {
     }
     
     func getFourMostConfidentTranslatedTags(completion: @escaping ([Tag]) -> Void) {
-        let sortedAndJoinedKeywords = keywordsOrderedByConfidence().joined(separator: ",")
+        let filteredKeywords = filteredKeywords()
+        let jointKeywords = filteredKeywords.joined(separator: ", ")
         
-        translate(keyword: sortedAndJoinedKeywords) { [weak self] result in
+        translate(keyword: jointKeywords) { [weak self] result in
             guard let self else { return }
             
             var uniqueValues = self.removeDuplicateValues(text: result)

--- a/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
@@ -80,10 +80,22 @@ final class VisionResultProcessor {
     }
     
     private func keywordsOrderedByConfidence() -> [String] {
-        let sortedLandmarks = visionResults.landmarks.sorted(by: { $0.confidence > $1.confidence }).map { $0.place }
-        let sortedKeywords = visionResults.keywords.sorted(by: { $0.confidence > $1.confidence }).map { $0.name }
+        let sortedLandmarks = visionResults.landmarks
+            .sorted(by: { $0.confidence > $1.confidence })
+            .map { $0.place }
+        let sortedKeywords = visionResults.keywords
+            .sorted(by: { $0.confidence > $1.confidence })
+            .map { $0.name }
         
-        return sortedLandmarks + sortedKeywords
+        var twoMostConfidentLandmarks: [String] = []
+        var index: Int = 0
+        while twoMostConfidentLandmarks.count < 2 {
+            if index >= sortedLandmarks.count { break }
+            twoMostConfidentLandmarks.append(sortedLandmarks[index])
+            index += 1
+        }
+        
+        return twoMostConfidentLandmarks + sortedKeywords
     }
     
     private func removeDuplicateValues(text: String) -> [String] {

--- a/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/VisionResultProcessor.swift
@@ -63,6 +63,22 @@ final class VisionResultProcessor {
         }
     }
     
+    private func filteredKeywords() -> [String] {
+        let filteredKeywords = keywordsOrderedByConfidence().difference(from: keywordsToFilter)
+        var result: [String] = []
+        
+        for change in filteredKeywords {
+            switch change {
+            case .insert(_, let keyword, _):
+                result.append(keyword)
+            case .remove:
+                continue
+            }
+        }
+        
+        return result
+    }
+    
     private func keywordsOrderedByConfidence() -> [String] {
         let sortedLandmarks = visionResults.landmarks.sorted(by: { $0.confidence > $1.confidence }).map { $0.place }
         let sortedKeywords = visionResults.keywords.sorted(by: { $0.confidence > $1.confidence }).map { $0.name }


### PR DESCRIPTION
Resolves #133 

### 구현사항
- 사진 분석 API가 반환한 키워드 중 의미 없는 태그 필터링 기능 구현
    - 키워드 번역 결과가 그때그때 다르게 오는 경우가 가끔씩 발견되어 영어 키워드로 필터링 로직 구현
- Landmark 유형의 키워드는 상위 2개만 포함하도록 수정

### 논의가 필요한 사항
- 번역 정확도가 구글 번역기가 조금 더 높은 것 같아 향후 버전 업데이트 시 API 변경 논의 필요
    - 예시: Goðafoss를 파파고는 아래와 같이 번역하지 못하지만, 구글 번역기는 고다포스라고 제대로 번역해줌
    
![image](https://github.com/Team-TravelGenie/TripChat/assets/98260324/393e6e2d-2cf2-4271-a6c7-ba3ee4de34ef)
 
- 구글 번역기의 경우 "Chute, Waterfall" 은 "슈트, 폭포", "Chute"는 "급류"로 각각 다르게 번역함. 번역을 보낼 때 단어별로 보낼 것인지, 묶어서 보낼 것인지 재논의 필요.
    - 참고: 파파고API는 두 경우 모두 "슈트"로만 번역