### PR TITLE
Fix/69/구글이미지서칭(쿼리수정, 작업 취소 및 재실행 로직)

### DIFF
--- a/TravelGenie/TravelGenie/Data/Network/RequestModel/ImageSearchRequestModel.swift
+++ b/TravelGenie/TravelGenie/Data/Network/RequestModel/ImageSearchRequestModel.swift
@@ -18,6 +18,8 @@ struct ImageSearchRequestModel: Encodable {
     let rights = "(cc_publicdomain%7Ccc_attribute%7Ccc_sharealike).-(cc_noncommercial)"
     let q: String
     let exactTerms: String
+    let siteSearch = "fbsbx.com"
+    let siteSearchFilter = "e"
     
     init(q: String, exactTerms: String) {
         self.q = q

--- a/TravelGenie/TravelGenie/Data/Network/RequestModel/ImageSearchRequestModel.swift
+++ b/TravelGenie/TravelGenie/Data/Network/RequestModel/ImageSearchRequestModel.swift
@@ -18,8 +18,6 @@ struct ImageSearchRequestModel: Encodable {
     let rights = "(cc_publicdomain%7Ccc_attribute%7Ccc_sharealike).-(cc_noncommercial)"
     let q: String
     let exactTerms: String
-    let siteSearch = "fbsbx.com"
-    let siteSearchFilter = "e"
     
     init(q: String, exactTerms: String) {
         self.q = q

--- a/TravelGenie/TravelGenie/Data/Network/RequestModel/ImageSearchRequestModel.swift
+++ b/TravelGenie/TravelGenie/Data/Network/RequestModel/ImageSearchRequestModel.swift
@@ -13,7 +13,7 @@ struct ImageSearchRequestModel: Encodable {
     let searchType = "image"
     let imgType = "photo"
     let imgColorType = "color"
-    let num: Int = 1
+    let num: Int = 5
     let safe = "active"
     let rights = "(cc_publicdomain%7Ccc_attribute%7Ccc_sharealike).-(cc_noncommercial)"
     let q: String

--- a/TravelGenie/TravelGenie/Data/Repository/DefaultImageSearchRepository.swift
+++ b/TravelGenie/TravelGenie/Data/Repository/DefaultImageSearchRepository.swift
@@ -25,8 +25,9 @@ final class DefaultImageSearchRepository: ImageSearchRepository {
                     completion(.failure(.emptyResponse))
                     return
                 }
+                let links = response.items.map { $0.link }
                 
-                completion(.success(link))
+                completion(.success(links))
             case .failure(let error):
                 completion(.failure(.moyaError(error)))
             }

--- a/TravelGenie/TravelGenie/Data/Repository/DefaultImageSearchRepository.swift
+++ b/TravelGenie/TravelGenie/Data/Repository/DefaultImageSearchRepository.swift
@@ -14,7 +14,7 @@ final class DefaultImageSearchRepository: ImageSearchRepository {
     func searchImage(
         with tags: [Tag],
         spot: String,
-        completion: @escaping (Result<String, ResponseError>) -> Void)
+        completion: @escaping (Result<[String], ResponseError>) -> Void)
     {
         let query = tags.map { $0.value }.joined(separator: " ")
         let requestModel = ImageSearchRequestModel(q: query, exactTerms: spot)

--- a/TravelGenie/TravelGenie/Domain/RepositoryInterface/ImageSearchRepository.swift
+++ b/TravelGenie/TravelGenie/Domain/RepositoryInterface/ImageSearchRepository.swift
@@ -9,5 +9,5 @@ protocol ImageSearchRepository {
     func searchImage(
         with tags: [Tag],
         spot: String,
-        completion: @escaping (Result<String, ResponseError>) -> Void)
+        completion: @escaping (Result<[String], ResponseError>) -> Void)
 }

--- a/TravelGenie/TravelGenie/Utility/ImageManager.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageManager.swift
@@ -10,6 +10,7 @@ import UIKit
 final class ImageManager {
     
     static let cache: URLCache = URLCache.shared
+    static var dataTask: URLSessionDataTask?
     
     static func retrieveImage(
         with url: String,
@@ -35,7 +36,7 @@ final class ImageManager {
         with request: URLRequest,
         completion: @escaping (Data) -> Void)
     {
-        let task = URLSession.shared.dataTask(with: request) { data, response, _ in
+        dataTask = URLSession.shared.dataTask(with: request) { data, response, _ in
             guard let data = data,
                   let response = response as? HTTPURLResponse,
                   (200..<300) ~= response.statusCode else { return }
@@ -49,6 +50,6 @@ final class ImageManager {
             }
 
         }
-        task.resume()
+        dataTask?.resume()
     }
 }

--- a/TravelGenie/TravelGenie/Utility/ImageManager.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageManager.swift
@@ -12,6 +12,8 @@ final class ImageManager {
     static let cache: URLCache = URLCache.shared
     static var dataTask: URLSessionDataTask?
     
+    // MARK: Internal
+    
     static func retrieveImage(
         with url: String,
         completion: @escaping (Data) -> Void)
@@ -27,6 +29,13 @@ final class ImageManager {
             }
         }
     }
+    
+    static func cancelRetrieveImageDataTask() {
+        dataTask?.cancel()
+        dataTask = nil
+    }
+    
+    // MARK: Private
     
     private static func loadImageFromCache(with request: URLRequest) -> Data? {
         return cache.cachedResponse(for: request)?.data


### PR DESCRIPTION
**기존 문제**
- ImageManager가 특정URL의 이미지를 다운로드 하지 못하는 문제가 있었음 (특정URL: FB 컨텐츠)

**해결**
- 해결1. Facebook 컨텐츠의 차단 URL을 받아오는 API에서 요청쿼리에서 해당 URL을 제외하도록 설정함 (fbsbx.com)
- 해결2. 이 외의 다운로드하지 못하는 이미지의 경우, ImageManager의 이미지를 가져오는 Task가 3초 이내에 이미지를 가져오지못한다면, 기존의 Task를 취소하고, 다음 순번의 URL에서 이미지를 가져오도록 구현함